### PR TITLE
prevent double rendering of initial view

### DIFF
--- a/src/Web/Scripts/app.ts
+++ b/src/Web/Scripts/app.ts
@@ -50,7 +50,7 @@ angular.module('app', ['ui.router', 'app.filters', 'app.services', 'app.directiv
 
         // <ui-view> contains a pre-rendered template for the current view
         // caching it will prevent a round-trip to a server at the first page load
-        var view = angular.element('#ui-view');
+        var view = angular.element('#initial-view');
         $templateCache.put(view.data('tmpl-url'), view.html());
 
         // Allows to retrieve UI Router state information from inside templates

--- a/src/Web/Views/_Layout.cshtml
+++ b/src/Web/Views/_Layout.cshtml
@@ -42,9 +42,13 @@
         </div>
     </header>
 
-    <div id="ui-view" class="container" ui-view data-tmpl-url="@Request.RequestContext.RouteData.DataTokens["templateUrl"]">
-        @RenderBody()
+    <div class="container" ui-view>
+        
     </div>
+
+    <script type="text/ng-template" id="initial-view" data-tmpl-url="@Request.RequestContext.RouteData.DataTokens["templateUrl"]">
+        @RenderBody()
+    </script>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.3/angular.min.js"></script>


### PR DESCRIPTION
Directives on the initial view will be linked twice before this update.
